### PR TITLE
Rename emby.key and fix spelling for series

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ List of available metrics:
 - emby_episode_count
 - emby_failed_login
 - emby_movie_count
-- emby_serie_count
+- emby_series_count
 - emby_stream_count
 - emby_transcoding_count
 - emby_user_count

--- a/collector/collector.go
+++ b/collector/collector.go
@@ -59,7 +59,7 @@ func New(ss StatusSource) prometheus.Collector {
 		),
 
 		SeriesCount: prometheus.NewDesc(
-			prometheus.BuildFQName(namespace, "serie", "count"),
+			prometheus.BuildFQName(namespace, "series", "count"),
 			"Number of tv shows available in Emby.",
 			labels,
 			nil,

--- a/collector/collector_test.go
+++ b/collector/collector_test.go
@@ -64,7 +64,7 @@ func TestEmbyCollector(t *testing.T) {
 			matches: []*regexp.Regexp{
 				regexp.MustCompile(`emby_device_count{server="mars"} 9`),
 				regexp.MustCompile(`emby_movie_count{server="mars"} 123`),
-				regexp.MustCompile(`emby_serie_count{server="mars"} 12`),
+				regexp.MustCompile(`emby_series_count{server="mars"} 12`),
 				regexp.MustCompile(`emby_episode_count{server="mars"} 362`),
 				regexp.MustCompile(`emby_user_count{server="mars"} 2`),
 				regexp.MustCompile(`emby_stream_count{server="mars"} 2`),

--- a/main.go
+++ b/main.go
@@ -48,7 +48,7 @@ func main() {
 		log.Fatal("address of Emby server must be specified with '-emby.addr' flag")
 	}
 	if *embyToken == "" {
-		log.Fatal("API key of Emby server must be specified with '-emby.key' flag")
+		log.Fatal("API key of Emby server must be specified with '-emby.token' flag")
 	}
 
 	ctx := context.Background()


### PR DESCRIPTION
When you don't provide a token it spits out the error

```
XXXX/XX/XX XX:XX:XX API key of Emby server must be specified with '-emby.key' flag
```
but the actual argument is named `emby.token`, not `emby.key`

---

The metric name for TV series is "serie" but the singular of series is series, not "serie"